### PR TITLE
feat: refactor valid time selection in order detail widget

### DIFF
--- a/lib/features/order/entity/order.dart
+++ b/lib/features/order/entity/order.dart
@@ -14,6 +14,7 @@ enum OrderAction {
 }
 
 enum OrderValidUntilUnit {
+  none(Duration.zero),
   m5(Duration(minutes: 5)),
   m15(Duration(minutes: 15)),
   m30(Duration(minutes: 30)),
@@ -28,6 +29,22 @@ enum OrderValidUntilUnit {
     String twoDigits(int n) => n.toString().padLeft(2, "0");
     String twoDigitMinutes = twoDigits(value.inMinutes.remainder(60).abs());
     return "$negativeSign${twoDigits(value.inHours)}:$twoDigitMinutes";
+  }
+
+  OrderValidUntilUnit next() {
+    int index = OrderValidUntilUnit.values.indexOf(this);
+    if (index == OrderValidUntilUnit.values.length - 1) {
+      return OrderValidUntilUnit.values.first;
+    }
+    return OrderValidUntilUnit.values[index + 1];
+  }
+
+  OrderValidUntilUnit previous() {
+    int index = OrderValidUntilUnit.values.indexOf(this);
+    if (index == 0) {
+      return OrderValidUntilUnit.values.last;
+    }
+    return OrderValidUntilUnit.values[index - 1];
   }
 
   final Duration value;

--- a/lib/features/order/widgets/order_detail.dart
+++ b/lib/features/order/widgets/order_detail.dart
@@ -15,8 +15,6 @@ class OrderDetailWidget extends StatefulWidget {
 }
 
 class _OrderDetailWidgetState extends State<OrderDetailWidget> with AutomaticKeepAliveClientMixin<OrderDetailWidget> {
-  final TextEditingController validTimeController = TextEditingController();
-
   Order? orderDetail;
   int? _priceIndex;
 
@@ -31,7 +29,6 @@ class _OrderDetailWidgetState extends State<OrderDetailWidget> with AutomaticKee
         if (orderDetail == null || orderDetail!.code != order.code) {
           orderDetail = order;
           _priceIndex = orderDetail!.availablePrice!.indexWhere((element) => element == orderDetail!.price);
-          validTimeController.text = OrderValidUntilUnit.m5.printDuration();
         }
       },
     );
@@ -149,31 +146,40 @@ class _OrderDetailWidgetState extends State<OrderDetailWidget> with AutomaticKee
                     ),
                   ],
           ),
-          _buildRow('${AppLocalizations.of(context)!.valid_until} (HH:MM)', [
-            DropdownMenu<OrderValidUntilUnit>(
-              leadingIcon: const Icon(Icons.timer),
-              selectedTrailingIcon: null,
-              enabled: orderDetail != null,
-              initialSelection: OrderValidUntilUnit.m5,
-              controller: validTimeController,
-              requestFocusOnTap: false,
-              onSelected: (OrderValidUntilUnit? unit) {
-                setState(() {
-                  orderDetail!.validUntilUnit = unit;
-                });
-              },
-              menuStyle: const MenuStyle(
-                alignment: Alignment.topLeft,
-              ),
-              inputDecorationTheme: const InputDecorationTheme(border: InputBorder.none),
-              dropdownMenuEntries: OrderValidUntilUnit.values.map<DropdownMenuEntry<OrderValidUntilUnit>>((OrderValidUntilUnit unit) {
-                return DropdownMenuEntry<OrderValidUntilUnit>(
-                  value: unit,
-                  label: unit.printDuration(),
-                );
-              }).toList(),
-            )
-          ]),
+          _buildRow(
+              '${AppLocalizations.of(context)!.valid_until} (HH:MM)',
+              orderDetail == null
+                  ? null
+                  : [
+                      Expanded(
+                        child: IconButton(
+                          onPressed: () {
+                            setState(() {
+                              orderDetail!.validUntilUnit = orderDetail!.validUntilUnit!.previous();
+                            });
+                          },
+                          icon: const Icon(Icons.keyboard_arrow_left_outlined),
+                        ),
+                      ),
+                      Expanded(
+                        child: Center(
+                          child: Text(
+                            orderDetail!.validUntilUnit!.printDuration(),
+                            style: Theme.of(context).textTheme.bodyLarge!,
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: IconButton(
+                          onPressed: () {
+                            setState(() {
+                              orderDetail!.validUntilUnit = orderDetail!.validUntilUnit!.next();
+                            });
+                          },
+                          icon: const Icon(Icons.keyboard_arrow_right_outlined),
+                        ),
+                      ),
+                    ]),
           _buildRow(AppLocalizations.of(context)!.auto_close, [
             Expanded(child: Container()),
             Expanded(

--- a/lib/features/order/widgets/stock_picker.dart
+++ b/lib/features/order/widgets/stock_picker.dart
@@ -49,7 +49,7 @@ class _StockPickerWidgetState extends State<StockPickerWidget> {
               onTap: () {
                 showModalBottomSheet(
                   constraints: BoxConstraints(
-                    maxHeight: MediaQuery.of(context).size.height * 0.75,
+                    maxHeight: MediaQuery.of(context).size.height * 0.55,
                   ),
                   isScrollControlled: true,
                   showDragHandle: true,
@@ -173,6 +173,7 @@ class _StockPickerWidgetState extends State<StockPickerWidget> {
       count: 1,
       type: widget.isOdd ? OrderType.stockOdd : OrderType.stock,
       availablePrice: getAvailablePrice(_snapShot!),
+      validUntilUnit: OrderValidUntilUnit.m5,
     ));
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: toc_machine_trading_fe
 description: "Status of trade agent, let user query analyzed stocks."
 publish_to: "none"
-version: 4.2.46+40105
+version: 4.2.47+40106
 
 environment:
   sdk: ">=3.2.5 <4.0.0"


### PR DESCRIPTION
- Added a 'none' option to the `OrderValidUntilUnit` enum
- Implemented `next` and `previous` methods to navigate through `OrderValidUntilUnit` values
- Removed `validTimeController` from `OrderDetailWidget`
- Replaced the dropdown menu for valid time selection with a set of buttons to navigate to the next and previous `OrderValidUntilUnit` values
- Lowered the maximum height for the stock picker modal from 75% to 55% of the screen height
- Set initial `validUntilUnit` to `OrderValidUntilUnit.m5` in the `_StockPickerWidgetState`
- Updated the app version from `4.2.46+40105` to `4.2.47+40106` in `pubspec.yaml`