### PR TITLE
feat: "Implement search caching and UI improvements"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: toc_machine_trading_fe
 description: "Status of trade agent, let user query analyzed stocks."
 publish_to: "none"
-version: 4.2.54+40114
+version: 4.2.55+40115
 
 environment:
   sdk: ">=3.2.5 <4.0.0"


### PR DESCRIPTION
- Add a `SearchCache` class to cache the search code
- Introduce a `TextEditingController` for the search field in `SearchFuturePage`
- Implement a clear button for the search field that clears the text field, cache and channel
- Change the `maintainState` parameter to `true` when navigating to `FutureRealTimePage`
- Populate the search field and channel with the cached search code if it's not empty on initialization
- Increment the version in `pubspec.yaml` from `4.2.54+40114` to `4.2.55+40115`