### PR TITLE
feat: improve futures handling and search functionality

### DIFF
--- a/lib/features/realtime/pages/future.dart
+++ b/lib/features/realtime/pages/future.dart
@@ -127,7 +127,11 @@ class _FutureRealTimePageState extends State<FutureRealTimePage> {
                                 '${futureTickArr[0].tick.priceChg == 0 ? '' : futureTickArr[0].tick.priceChg > 0 ? '+' : '-'} ${futureTickArr[0].tick.priceChg.abs().toStringAsFixed(0)}',
                                 fontSize: 45,
                                 bold: true,
-                                color: futureTickArr[0].tick.priceChg > 0 ? Colors.redAccent : Colors.greenAccent,
+                                color: futureTickArr[0].tick.priceChg == 0
+                                    ? Colors.black
+                                    : futureTickArr[0].tick.priceChg > 0
+                                        ? Colors.redAccent
+                                        : Colors.greenAccent,
                               ),
                             ),
                           ),
@@ -266,6 +270,8 @@ class _FutureRealTimePageState extends State<FutureRealTimePage> {
               CustomTick(pb.FutureRealTimeTickMessage(
                 close: msg.snapshot.close,
                 priceChg: msg.snapshot.changePrice,
+                dateTime: DateTime.fromMicrosecondsSinceEpoch(msg.snapshot.ts.toInt() ~/ 1000).add(const Duration(hours: -8)).toIso8601String(),
+                volume: msg.snapshot.volume,
               )),
             );
           });

--- a/lib/features/realtime/pages/search.dart
+++ b/lib/features/realtime/pages/search.dart
@@ -81,6 +81,10 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
                       if (value.isNotEmpty) {
                         _channel!.sink.add(value);
                         SearchCache.setCode(value);
+                      } else {
+                        setState(() {
+                          futureList = [];
+                        });
                       }
                     },
                     decoration: InputDecoration(
@@ -89,7 +93,9 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
                         onPressed: () {
                           _controller.clear();
                           SearchCache.clear();
-                          _channel!.sink.add('');
+                          setState(() {
+                            futureList = [];
+                          });
                         },
                         icon: const Icon(Icons.clear),
                       ),
@@ -152,6 +158,10 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
     _channel!.stream.listen(
       (message) {
         final msg = jsonDecode(message);
+        if (msg['futures'] == null) {
+          return;
+        }
+
         List<FutureDetail> result = [];
         for (var item in msg['futures']) {
           result.add(FutureDetail.fromJson(item));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: toc_machine_trading_fe
 description: "Status of trade agent, let user query analyzed stocks."
 publish_to: "none"
-version: 4.2.55+40115
+version: 4.2.56+40116
 
 environment:
   sdk: ">=3.2.5 <4.0.0"


### PR DESCRIPTION
- Change the color coding for price change in `future.dart` to include black color for no change.
- Capture date and volume information in real-time tick message in `future.dart`.
- In `search.dart`, reset the future list when the search value is empty.
- Add a condition in `search.dart` to return the function if the fetched message doesn't contain futures.
- Increment the version number in `pubspec.yaml` from 4.2.55 to 4.2.56.