### PR TITLE
refactor: refactor ad handling and update app version

### DIFF
--- a/lib/features/news/pages/news.dart
+++ b/lib/features/news/pages/news.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:toc_machine_trading_fe/core/ad/ad.dart';
 import 'package:toc_machine_trading_fe/core/api/twse.dart';
-import 'package:toc_machine_trading_fe/features/universal/repo/settings.dart';
+import 'package:toc_machine_trading_fe/features/universal/widgets/ad.dart';
 import 'package:toc_machine_trading_fe/features/universal/widgets/app_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -16,27 +14,7 @@ class NewsPage extends StatefulWidget {
 }
 
 class _NewsPageState extends State<NewsPage> {
-  late Orientation _currentOrientation;
-
   Future<List<TWSENews>> newsList = TWSE.getTWSENews();
-
-  bool _removeAds = false;
-  bool _isLoaded = false;
-  BannerAd? _inlineAdaptiveAd;
-  AdSize? _adSize;
-
-  @override
-  void initState() {
-    checkRemoveAds();
-    super.initState();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _currentOrientation = MediaQuery.of(context).orientation;
-    _loadAd();
-  }
 
   @override
   void setState(VoidCallback fn) {
@@ -48,144 +26,73 @@ class _NewsPageState extends State<NewsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: topAppBar(
-          context,
-          AppLocalizations.of(context)!.news,
-        ),
-        body: FutureBuilder<List<TWSENews>>(
-          future: newsList,
-          builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              return ListView.separated(
-                separatorBuilder: (context, index) {
-                  if (index == 5 && !_removeAds) {
-                    return _getAdUnit();
-                  }
-                  return const Divider(
-                    thickness: 3,
-                    height: 0,
-                    indent: 40,
-                  );
-                },
-                primary: false,
-                itemCount: snapshot.data!.length,
-                itemBuilder: (context, index) {
-                  return ListTile(
-                    title: Text(snapshot.data![index].title!),
-                    subtitle: Align(
-                      alignment: Alignment.centerRight,
-                      child: Text(snapshot.data![index].date!),
-                    ),
-                    onTap: snapshot.data![index].url == ''
-                        ? null
-                        : () {
-                            launchUrl(Uri.parse(snapshot.data![index].url!)).then((value) {
-                              if (!value) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(
-                                      AppLocalizations.of(context)!.unknown_error,
-                                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: Colors.red),
-                                    ),
-                                    duration: const Duration(seconds: 2),
-                                  ),
-                                );
-                              }
-                            }).catchError((e) {
+      appBar: topAppBar(
+        context,
+        AppLocalizations.of(context)!.news,
+      ),
+      body: FutureBuilder<List<TWSENews>>(
+        future: newsList,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            return ListView.separated(
+              separatorBuilder: (context, index) {
+                if (index == 5) {
+                  return const AdBanner();
+                }
+                return const Divider(
+                  thickness: 3,
+                  height: 0,
+                  indent: 40,
+                );
+              },
+              primary: false,
+              itemCount: snapshot.data!.length,
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text(snapshot.data![index].title!),
+                  subtitle: Align(
+                    alignment: Alignment.centerRight,
+                    child: Text(snapshot.data![index].date!),
+                  ),
+                  onTap: snapshot.data![index].url == ''
+                      ? null
+                      : () {
+                          launchUrl(Uri.parse(snapshot.data![index].url!)).then((value) {
+                            if (!value) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
                                   content: Text(
-                                    e.toString(),
+                                    AppLocalizations.of(context)!.unknown_error,
                                     style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: Colors.red),
                                   ),
                                   duration: const Duration(seconds: 2),
                                 ),
                               );
-                            });
-                          },
-                  );
-                },
-              );
-            }
-            return Center(
-              child: SpinKitWave(
-                color: Theme.of(context).colorScheme.primary,
-                size: 35.0,
-              ),
+                            }
+                          }).catchError((e) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                  e.toString(),
+                                  style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: Colors.red),
+                                ),
+                                duration: const Duration(seconds: 2),
+                              ),
+                            );
+                          });
+                        },
+                );
+              },
             );
-          },
-        ));
-  }
-
-  void _loadAd() async {
-    await _inlineAdaptiveAd?.dispose();
-    setState(() {
-      _inlineAdaptiveAd = null;
-      _isLoaded = false;
-    });
-
-    AdSize size = AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(
-      _adWidth().truncate(),
-    );
-
-    _inlineAdaptiveAd = BannerAd(
-      adUnitId: AD.bannerAdUnitId,
-      size: size,
-      request: const AdRequest(),
-      listener: BannerAdListener(
-        onAdLoaded: (Ad ad) async {
-          BannerAd bannerAd = (ad as BannerAd);
-          final AdSize? size = await bannerAd.getPlatformAdSize();
-          if (size == null) {
-            return;
           }
-
-          setState(() {
-            _inlineAdaptiveAd = bannerAd;
-            _isLoaded = true;
-            _adSize = size;
-          });
-        },
-        onAdFailedToLoad: (Ad ad, LoadAdError error) {
-          ad.dispose();
+          return Center(
+            child: SpinKitWave(
+              color: Theme.of(context).colorScheme.primary,
+              size: 35.0,
+            ),
+          );
         },
       ),
     );
-    await _inlineAdaptiveAd!.load();
-  }
-
-  double _adWidth() {
-    return MediaQuery.of(context).size.width - (20);
-  }
-
-  Widget _getAdUnit() {
-    return OrientationBuilder(
-      builder: (context, orientation) {
-        if (_currentOrientation == orientation && _inlineAdaptiveAd != null && _isLoaded && _adSize != null) {
-          return Align(
-            child: SizedBox(
-              width: _adWidth(),
-              height: _adSize!.height.toDouble(),
-              child: AdWidget(
-                ad: _inlineAdaptiveAd!,
-              ),
-            ),
-          );
-        }
-        // Reload the ad if the orientation changes.
-        if (_currentOrientation != orientation) {
-          _currentOrientation = orientation;
-          _loadAd();
-        }
-        return Container();
-      },
-    );
-  }
-
-  Future<void> checkRemoveAds() async {
-    final bool value = await SettingsRepo.isAdsRemoved();
-    setState(() {
-      _removeAds = value;
-    });
   }
 }

--- a/lib/features/realtime/pages/search.dart
+++ b/lib/features/realtime/pages/search.dart
@@ -1,13 +1,12 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:toc_machine_trading_fe/core/ad/ad.dart';
 import 'package:toc_machine_trading_fe/core/api/api.dart';
 import 'package:toc_machine_trading_fe/features/realtime/entity/future.dart';
 import 'package:toc_machine_trading_fe/features/realtime/pages/future.dart';
-import 'package:toc_machine_trading_fe/features/universal/repo/settings.dart';
+import 'package:toc_machine_trading_fe/features/universal/widgets/ad.dart';
 import 'package:toc_machine_trading_fe/features/universal/widgets/app_bar.dart';
 import 'package:web_socket_channel/io.dart';
 
@@ -35,26 +34,12 @@ class SearchFuturePage extends StatefulWidget {
 
 class _SearchFuturePageState extends State<SearchFuturePage> {
   final TextEditingController _controller = TextEditingController();
-  late Orientation _currentOrientation;
   late IOWebSocketChannel? _channel;
-
-  bool _removeAds = false;
-  bool _isLoaded = false;
-  BannerAd? _inlineAdaptiveAd;
-  AdSize? _adSize;
 
   @override
   void initState() {
-    checkRemoveAds();
     super.initState();
     initialWS();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _currentOrientation = MediaQuery.of(context).orientation;
-    _loadAd();
   }
 
   @override
@@ -78,76 +63,85 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
       onPopInvoked: (_) {
         SearchCache.clear();
       },
-      child: Scaffold(
-        appBar: topAppBar(
-          context,
-          AppLocalizations.of(context)!.future,
-          automaticallyImplyLeading: true,
-        ),
-        body: SizedBox(
-          child: Padding(
-            padding: const EdgeInsets.only(left: 5, right: 5),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: TextField(
-                    controller: _controller,
-                    onChanged: (value) {
-                      if (value.isNotEmpty) {
-                        _channel!.sink.add(value);
-                        SearchCache.setCode(value);
-                      } else {
-                        setState(() {
-                          futureList = [];
-                        });
-                      }
-                    },
-                    decoration: InputDecoration(
-                      labelText: AppLocalizations.of(context)!.search,
-                      suffixIcon: IconButton(
-                        onPressed: () {
-                          _controller.clear();
-                          SearchCache.clear();
+      child: GestureDetector(
+        onTap: () {
+          FocusScopeNode currentFocus = FocusScope.of(context);
+          if (!currentFocus.hasPrimaryFocus) {
+            currentFocus.unfocus();
+          }
+        },
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: topAppBar(
+            context,
+            AppLocalizations.of(context)!.future,
+            automaticallyImplyLeading: true,
+          ),
+          body: SizedBox(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 5, right: 5),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TextField(
+                      controller: _controller,
+                      onChanged: (value) {
+                        if (value.isNotEmpty) {
+                          _channel!.sink.add(value);
+                          SearchCache.setCode(value);
+                        } else {
                           setState(() {
                             futureList = [];
                           });
-                        },
-                        icon: const Icon(Icons.clear),
+                        }
+                      },
+                      decoration: InputDecoration(
+                        labelText: AppLocalizations.of(context)!.search,
+                        suffixIcon: IconButton(
+                          onPressed: () {
+                            _controller.clear();
+                            SearchCache.clear();
+                            setState(() {
+                              futureList = [];
+                            });
+                          },
+                          icon: const Icon(Icons.clear),
+                        ),
                       ),
                     ),
                   ),
-                ),
-                Expanded(
-                  flex: 2,
-                  child: ListView.builder(
-                    itemCount: futureList.length,
-                    itemBuilder: (BuildContext context, int index) {
-                      return ListTile(
-                        title: Text(futureList[index].name!),
-                        subtitle: Text(futureList[index].code!),
-                        onTap: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute(
-                              maintainState: true,
-                              fullscreenDialog: false,
-                              builder: (context) => FutureRealTimePage(
-                                code: futureList[index].code!,
+                  Expanded(
+                    flex: 2,
+                    child: ListView.builder(
+                      itemCount: futureList.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return ListTile(
+                          title: Text(futureList[index].name!),
+                          subtitle: Text(futureList[index].code!),
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                maintainState: true,
+                                fullscreenDialog: false,
+                                builder: (context) => FutureRealTimePage(
+                                  code: futureList[index].code!,
+                                ),
                               ),
-                            ),
-                          );
-                        },
-                      );
-                    },
+                            );
+                          },
+                        );
+                      },
+                    ),
                   ),
-                ),
-                _removeAds
-                    ? const SizedBox.shrink()
-                    : Expanded(
-                        child: SafeArea(child: _getAdUnit()),
-                      ),
-              ],
+                  const Expanded(
+                    child: SafeArea(
+                      child: AdBanner(),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -185,78 +179,6 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
       },
       onDone: () {},
       onError: (error) {},
-    );
-  }
-
-  Future<void> checkRemoveAds() async {
-    final bool value = await SettingsRepo.isAdsRemoved();
-    setState(() {
-      _removeAds = value;
-    });
-  }
-
-  void _loadAd() async {
-    await _inlineAdaptiveAd?.dispose();
-    setState(() {
-      _inlineAdaptiveAd = null;
-      _isLoaded = false;
-    });
-
-    AdSize size = AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(
-      _adWidth().truncate(),
-    );
-
-    _inlineAdaptiveAd = BannerAd(
-      adUnitId: AD.bannerAdUnitId,
-      size: size,
-      request: const AdRequest(),
-      listener: BannerAdListener(
-        onAdLoaded: (Ad ad) async {
-          BannerAd bannerAd = (ad as BannerAd);
-          final AdSize? size = await bannerAd.getPlatformAdSize();
-          if (size == null) {
-            return;
-          }
-
-          setState(() {
-            _inlineAdaptiveAd = bannerAd;
-            _isLoaded = true;
-            _adSize = size;
-          });
-        },
-        onAdFailedToLoad: (Ad ad, LoadAdError error) {
-          ad.dispose();
-        },
-      ),
-    );
-    await _inlineAdaptiveAd!.load();
-  }
-
-  double _adWidth() {
-    return MediaQuery.of(context).size.width - (20);
-  }
-
-  Widget _getAdUnit() {
-    return OrientationBuilder(
-      builder: (context, orientation) {
-        if (_currentOrientation == orientation && _inlineAdaptiveAd != null && _isLoaded && _adSize != null) {
-          return Align(
-            child: SizedBox(
-              width: _adWidth(),
-              height: _adSize!.height.toDouble(),
-              child: AdWidget(
-                ad: _inlineAdaptiveAd!,
-              ),
-            ),
-          );
-        }
-        // Reload the ad if the orientation changes.
-        if (_currentOrientation != orientation) {
-          _currentOrientation = orientation;
-          _loadAd();
-        }
-        return Container();
-      },
     );
   }
 }

--- a/lib/features/universal/widgets/ad.dart
+++ b/lib/features/universal/widgets/ad.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:toc_machine_trading_fe/core/ad/ad.dart';
+import 'package:toc_machine_trading_fe/features/universal/repo/settings.dart';
+
+class AdBanner extends StatefulWidget {
+  const AdBanner({super.key});
+
+  @override
+  State<AdBanner> createState() => _AdBannerState();
+}
+
+class _AdBannerState extends State<AdBanner> {
+  bool _removeAds = false;
+  bool _isLoaded = false;
+  BannerAd? _inlineAdaptiveAd;
+  AdSize? _adSize;
+
+  @override
+  void initState() {
+    checkRemoveAds();
+    super.initState();
+    _loadAd();
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    if (mounted) {
+      super.setState(fn);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _removeAds
+        ? const SizedBox.shrink()
+        : (_inlineAdaptiveAd != null && _isLoaded && _adSize != null)
+            ? Align(
+                child: SizedBox(
+                  width: _adWidth(),
+                  height: _adSize!.height.toDouble(),
+                  child: AdWidget(
+                    ad: _inlineAdaptiveAd!,
+                  ),
+                ),
+              )
+            : Container();
+  }
+
+  Future<void> checkRemoveAds() async {
+    final bool value = await SettingsRepo.isAdsRemoved();
+    setState(() {
+      _removeAds = value;
+    });
+  }
+
+  void _loadAd() async {
+    await _inlineAdaptiveAd?.dispose();
+    setState(() {
+      _inlineAdaptiveAd = null;
+      _isLoaded = false;
+    });
+
+    AdSize size = AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(
+      _adWidth().truncate(),
+    );
+
+    _inlineAdaptiveAd = BannerAd(
+      adUnitId: AD.bannerAdUnitId,
+      size: size,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (Ad ad) async {
+          BannerAd bannerAd = (ad as BannerAd);
+          final AdSize? size = await bannerAd.getPlatformAdSize();
+          if (size == null) {
+            return;
+          }
+
+          setState(() {
+            _inlineAdaptiveAd = bannerAd;
+            _isLoaded = true;
+            _adSize = size;
+          });
+        },
+        onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          ad.dispose();
+        },
+      ),
+    );
+    await _inlineAdaptiveAd!.load();
+  }
+
+  double _adWidth() {
+    return MediaQuery.of(context).size.width - (20);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: toc_machine_trading_fe
 description: "Status of trade agent, let user query analyzed stocks."
 publish_to: "none"
-version: 4.2.57+40117
+version: 4.2.58+40118
 
 environment:
   sdk: ">=3.2.5 <4.0.0"


### PR DESCRIPTION
- Removed the imports of `google_mobile_ads` and `toc_machine_trading_fe/core/ad/ad.dart` from `news.dart` and `search.dart`.
- Instead, imported `toc_machine_trading_fe/features/universal/widgets/ad.dart` in the same files.
- Removed the handling of ad loading and orientation changes from `_NewsPageState` and `_SearchFuturePageState`.
- In `news.dart` and `search.dart`, replaced the custom ad loading logic with a simple `AdBanner` widget.
- Created a new file `ad.dart` in the `universal/widgets` directory, which contains the `AdBanner` widget. This widget handles the ad loading and orientation change logic that was previously in `news.dart` and `search.dart`.
- In `search.dart`, added logic to unfocus the text field when the user taps elsewhere on the screen.
- Updated the app version in `pubspec.yaml` from `4.2.57+40117` to `4.2.58+40118`.