### PR TITLE
fix: "Refactor `SearchCache.getCode()` handling and update version"

### DIFF
--- a/lib/features/realtime/pages/search.dart
+++ b/lib/features/realtime/pages/search.dart
@@ -158,10 +158,13 @@ class _SearchFuturePageState extends State<SearchFuturePage> {
       },
     );
     await _channel!.ready;
-    if (SearchCache.getCode().isNotEmpty) {
-      _controller.text = SearchCache.getCode();
-      _channel!.sink.add(SearchCache.getCode());
+    String code = SearchCache.getCode();
+    if (code.isEmpty) {
+      code = "MXF";
+      SearchCache.setCode(code);
     }
+    _controller.text = code;
+    _channel!.sink.add(SearchCache.getCode());
     _channel!.stream.listen(
       (message) {
         final msg = jsonDecode(message);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -335,10 +335,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "301f67ee9b87f04aef227f57f13f126fa7b13543c8e7a93f25c5d2d534c28a4a"
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_web:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_purchase_storekit
-      sha256: c13e4fee493dff3e956ebd24f80656f5ddbf876a8d12817d6fbe52d90e7c2068
+      sha256: "3eea5e173fca0a59ab2fcec5201bea14bb808dfad01004d2b1d7bfdb9244c5e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.16"
   intl:
     dependency: "direct main"
     description:
@@ -1022,10 +1022,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: f12f8d8a99784b863e8b85e4a9a5e3cf1839d6803d2c0c3e0533a8f3c5a992a7
+      sha256: "7affdf9d680c015b11587181171d3cad8093e449db1f7d9f0f08f4f33d24f9a0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.13.0"
+    version: "3.13.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: toc_machine_trading_fe
 description: "Status of trade agent, let user query analyzed stocks."
 publish_to: "none"
-version: 4.2.62+40122
+version: 4.2.63+40123
 
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
- Modify the handling of the `SearchCache.getCode()` method in `search.dart`. If there's no code, it now defaults to `MXF` and updates the `SearchCache` accordingly.
- The `_controller.text` and `_channel.sink.add` now always get `code` instead of directly using `SearchCache.getCode()`.
- Update the version number in `pubspec.yaml` from `4.2.62+40122` to `4.2.63+40123`.