### PR TITLE
chore: "Refactor UI components and update dependencies"

### DIFF
--- a/lib/features/balance/pages/category.dart
+++ b/lib/features/balance/pages/category.dart
@@ -12,7 +12,8 @@ class BalanceCategoryPage extends StatefulWidget {
   State<BalanceCategoryPage> createState() => _BalanceCategoryPageState();
 }
 
-class _BalanceCategoryPageState extends State<BalanceCategoryPage> with TickerProviderStateMixin {
+class _BalanceCategoryPageState extends State<BalanceCategoryPage>
+    with TickerProviderStateMixin {
   late final TabController _tabController;
 
   int _selectedIndex = 0;
@@ -72,13 +73,13 @@ class _BalanceCategoryPageState extends State<BalanceCategoryPage> with TickerPr
       child: SegmentedButton<int>(
         showSelectedIcon: false,
         style: ButtonStyle(
-          side: MaterialStateProperty.all(
+          side: WidgetStateProperty.all(
             BorderSide(
               color: Theme.of(context).colorScheme.onSurface.withOpacity(0.3),
             ),
           ),
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          shape: MaterialStateProperty.all(
+          shape: WidgetStateProperty.all(
             RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(30),
             ),

--- a/lib/features/order/widgets/place_order.dart
+++ b/lib/features/order/widgets/place_order.dart
@@ -17,7 +17,8 @@ class PlaceOrderWidget extends StatefulWidget {
 }
 
 class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
-  final StreamController<Order> _orderStreamController = StreamController<Order>.broadcast();
+  final StreamController<Order> _orderStreamController =
+      StreamController<Order>.broadcast();
 
   OrderAction _action = OrderAction.none;
   Order? orderDetail;
@@ -55,7 +56,8 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
             ),
             Expanded(
               flex: 5,
-              child: OrderOptionWidget(orderStreamController: _orderStreamController),
+              child: OrderOptionWidget(
+                  orderStreamController: _orderStreamController),
             ),
             Expanded(
               flex: 2,
@@ -65,7 +67,8 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                     child: Column(
                       children: [
                         Expanded(child: _buildActionButton(OrderAction.buy)),
-                        Expanded(child: _buildActionButton(OrderAction.sellFirst)),
+                        Expanded(
+                            child: _buildActionButton(OrderAction.sellFirst)),
                       ],
                     ),
                   ),
@@ -73,7 +76,8 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                     child: Column(
                       children: [
                         Expanded(child: _buildActionButton(OrderAction.sell)),
-                        Expanded(child: _buildActionButton(OrderAction.buyLater)),
+                        Expanded(
+                            child: _buildActionButton(OrderAction.buyLater)),
                       ],
                     ),
                   ),
@@ -85,9 +89,10 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                 width: double.infinity,
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: (orderDetail != null && _action != OrderAction.none)
-                        ? Theme.of(context).colorScheme.secondary
-                        : Theme.of(context).colorScheme.background,
+                    backgroundColor:
+                        (orderDetail != null && _action != OrderAction.none)
+                            ? Theme.of(context).colorScheme.secondary
+                            : Theme.of(context).colorScheme.surface,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
                     ),
@@ -149,7 +154,10 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                     AppLocalizations.of(context)!.place_order,
                     style: Theme.of(context).textTheme.titleMedium!.copyWith(
                           fontWeight: FontWeight.bold,
-                          color: (orderDetail != null && _action != OrderAction.none) ? Colors.white : Colors.grey,
+                          color: (orderDetail != null &&
+                                  _action != OrderAction.none)
+                              ? Colors.white
+                              : Colors.grey,
                         ),
                   ),
                 ),
@@ -192,7 +200,7 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                 borderRadius: BorderRadius.circular(10),
               ),
               backgroundColor: _action != action
-                  ? Theme.of(context).colorScheme.background
+                  ? Theme.of(context).colorScheme.surface
                   : _action == OrderAction.buy
                       ? Colors.redAccent
                       : _action == OrderAction.sell
@@ -203,7 +211,8 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
             ),
             onPressed: orderDetail == null
                 ? null
-                : (action == OrderAction.sellFirst || action == OrderAction.buyLater)
+                : (action == OrderAction.sellFirst ||
+                        action == OrderAction.buyLater)
                     ? null
                     : () {
                         setState(() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: cronet_http
-      sha256: "9b9f00ae48971bc8a8cbdd4528bd35511adce00fb79d1ebf9f9907667056640f"
+      sha256: "013c515e2caf1381fcdc577b0c1a3625021b0df32880c20c06757fc616d375bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   crypto:
     dependency: transitive
     description:
@@ -327,10 +327,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      sha256: "8cfa53010a294ff095d7be8fa5bb15f2252c50018d69c5104851303f3ff92510"
+      sha256: b768a7dab26d6186b68e2831b3104f8968154f0f4fdbf66e7c2dd7bdf299daaf
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: "499558e919997adfc45809a66caf0b95b91393e23289dd2826b152f8f04e6611"
+      sha256: "6f8e04339f96cb32879acb181c60b2c1e2310ff86f3c62bcd1afcfb4b28b665d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.9.2"
   js:
     dependency: transitive
     description:
@@ -838,10 +838,10 @@ packages:
     dependency: "direct main"
     description:
       name: toc_trade_protobuf
-      sha256: "39b3ddd0a3a0132806821a830d655f889a0a3e0a1b9f3217b2172ac5b9152286"
+      sha256: "73ff9dadde6b6dc391132151cc51dc6ee9a376f5cb91997f0b365b5c92dba4a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.7"
+    version: "0.1.10"
   typed_data:
     dependency: transitive
     description:
@@ -990,10 +990,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket
-      sha256: bfe704c186c6e32a46f6607f94d079cd0b747b9a489fceeecc93cd3adb98edd5
+      sha256: "217f49b5213796cb508d6a942a5dc604ce1cb6a0a6b3d8cb3f0c314f0ecea712"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   web_socket_channel:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   syncfusion_flutter_charts: ^25.1.39+1
   syncfusion_flutter_treemap: ^25.1.39+1
   table_calendar: ^3.0.9
-  toc_trade_protobuf: ^0.1.7
+  toc_trade_protobuf: ^0.1.10
   url_launcher: ^6.2.4
   wakelock: ^0.6.2
   web_socket_channel: ^3.0.0


### PR DESCRIPTION
- The `_BalanceCategoryPageState` class now extends `State<BalanceCategoryPage>` with `TickerProviderStateMixin` on a new line.
- `MaterialStateProperty.all` is replaced with `WidgetStateProperty.all` in `SegmentedButton` style properties.
- In the `_PlaceOrderWidgetState` class, the initialization of `_orderStreamController` and widget properties are arranged in a more readable format with new lines.
- The unchanged background color for the `ElevatedButton` and `RoundedActionButton` is now `Theme.of(context).colorScheme.surface` instead of `Theme.of(context).colorScheme.background`.
- The version of `toc_trade_protobuf` dependency is updated from `^0.1.7` to `^0.1.10` in `pubspec.yaml`.